### PR TITLE
Support new reinit syntax passing the cell

### DIFF
--- a/src/splines/bezier_values.jl
+++ b/src/splines/bezier_values.jl
@@ -293,7 +293,9 @@ function _cellvalues_bezier_extraction_higher_order!(
 
 end
 
-function Ferrite.reinit!(cv::BezierCellValues, bc::BezierCoords)
+Ferrite.reinit!(cv::BezierCellValues, bc::BezierCoords) = reinit!(cv, nothing, bc)
+
+function Ferrite.reinit!(cv::BezierCellValues, ::Union{Ferrite.AbstractCell, Nothing}, bc::BezierCoords)
     set_bezier_operator!(cv, bc.beo[], bc.w)
     return reinit!(cv, (bc.xb, bc.wb))
 end
@@ -338,7 +340,9 @@ function reinit_values!(cv::BezierCellValues, bc::BezierCoords)
     return nothing
 end
 
-function Ferrite.reinit!(cv::BezierFacetValues, bc::BezierCoords, face_nr::Int)
+Ferrite.reinit!(fv::BezierFacetValues, bc::BezierCoords, facet_nr::Int) = reinit!(fv, nothing, bc, facet_nr)
+
+function Ferrite.reinit!(cv::BezierFacetValues, _, bc::BezierCoords, face_nr::Int)
     set_bezier_operator!(cv, bc.beo[], bc.w)
     return reinit!(cv, (bc.xb, bc.wb), face_nr)
 end

--- a/test/test_values.jl
+++ b/test/test_values.jl
@@ -188,6 +188,20 @@ end
             end
         end
     end
+
+    # Test reinit! with the cell given 
+    cell = getcells(grid, 1)
+    bc = getcoordinates(grid, 1)
+    reinit!(cv, bc)
+    ∇N = shape_gradient(cv, 1, 1)
+    reinit!(cv, getcoordinates(grid, 2))
+    reinit!(cv, cell, bc)
+    @test ∇N ≈ shape_gradient(cv, 1, 1)
+    reinit!(fv, bc, 1)
+    ∇N = shape_gradient(fv, 1, 1)
+    reinit!(fv, getcoordinates(grid, 2), 1)
+    reinit!(fv, cell, bc, 1)
+    @test ∇N ≈ shape_gradient(fv, 1, 1)
     
     cellnum, faceidx = (9, 3)
     addfacetset!(grid, "left_facet", (x)-> x[1] ≈ -4.0)


### PR DESCRIPTION
To follow the "new" extended syntax in Ferrite when `reinit!` is called with the cell argument, this PR ensures that that syntax can be used without error. 

This PR does not support non-identity mappings in IGA (if that is ever used), but simply makes it possible to use IGA.jl in combination with generic Ferrite code in e.g. FerriteAssembly. 